### PR TITLE
Fixed swallowed exception when exception is raised.

### DIFF
--- a/lib/wiremock.helper.ts
+++ b/lib/wiremock.helper.ts
@@ -184,8 +184,8 @@ export class WiremockHelper {
           } else {
             try {
               resolve(JSON.parse(responseBody));
-            } finally {
-              resolve(responseBody);
+            } catch(e) {
+                resolve(responseBody);
             }
           }
         });
@@ -195,7 +195,7 @@ export class WiremockHelper {
         reject('[WiremockHelper] HTTP call to Wiremock failed!\n' + err);
       });
 
-      if (allOptions.method === 'POST' && body != null) {
+      if ((allOptions.method === 'POST' || allOptions.method === 'PUT' || allOptions.method === 'PATCH') && body != null) {
         req.write(body);
       }
       req.end();


### PR DESCRIPTION
I was using your library fro some project and found the exception was swallowed when http call caused exception. Here is the fix for that. I will be happy if it will be merged.