### PR TITLE
Fixing the request header user-agent enrichment for all verification requests

### DIFF
--- a/lib/wiremock-request-journal.helper.spec.ts
+++ b/lib/wiremock-request-journal.helper.spec.ts
@@ -1,0 +1,36 @@
+import { expect } from 'chai';
+import { WiremockRequestJournalHelper } from './wiremock-request-journal.helper';
+import { stubForOkResponseWithReferredBody, stubForOkResponseWithBody } from './builders/stub-mapping-builder'
+import { forGetRequestMatchingUrl , matches} from './builders/request-pattern-builder'
+const nock = require('nock');
+const LOCALHOST_URL = 'http://localhost:8080';
+
+describe('WiremockRequestJournalHelper', () => {
+
+    it('should add "User-Agent" mapping to header when request journal is called', () => {
+        const subject = new WiremockRequestJournalHelper(LOCALHOST_URL, "myCustomBrowser");
+        const journalScope = nock(LOCALHOST_URL)
+            .post('/__admin/requests/count',JSON.stringify(
+                {
+                    method: 'GET',
+                    url: '/sample/path',
+                    queryParameters: undefined,
+                    cookies: undefined,
+                    headers: {
+                        myCustomHeader: { matches: 'someValue.*' },
+                        'User-Agent': { contains: 'Mycustombrowser' }
+                    }
+                }
+            ))
+            .reply(200, JSON.stringify({count: 100}));
+
+        const mappingBuilder = forGetRequestMatchingUrl("/sample/path")
+            .withHeader("myCustomHeader", matches("someValue.*"));
+
+        return subject.getRequestCount(mappingBuilder.build()).then((count: number) => {
+            expect(count).to.be.eql(100);
+            expect(journalScope.isDone()).to.be.true;
+        });
+    });
+
+});

--- a/lib/wiremock-request-journal.helper.ts
+++ b/lib/wiremock-request-journal.helper.ts
@@ -8,20 +8,18 @@ export class WiremockRequestJournalHelper extends WiremockHelper {
 
     private readonly browserName: string;
 
-    constructor(baseUrl?: string, browserName?: string) {
+    constructor(baseUrl?: string, browserName:string = "") {
         super(baseUrl);
         this.browserName = browserName.charAt(0).toUpperCase() + browserName.toLowerCase().slice(1);
     }
 
     private addBrowserHeader(query: RequestPattern): RequestPattern {
-        return {
-            ...query,
-            headers: {
-                'User-Agent': {
-                    contains: this.browserName
-                }
-            }
-        };
+        if (this.browserName !== "") {
+            query.headers['User-Agent'] = {
+                contains: this.browserName
+            };
+        }
+        return query;
     }
 
     /**
@@ -54,7 +52,7 @@ export class WiremockRequestJournalHelper extends WiremockHelper {
         return super.performRequest({
             method: 'POST',
             path: '/__admin/requests/count'
-        }, JSON.stringify(query))
+        }, JSON.stringify(this.addBrowserHeader(query)))
             .catch(e => {
                 console.warn("Verification fallback to 0. %s", e);
                 return {count: 0};

--- a/lib/wiremock.helper.spec.ts
+++ b/lib/wiremock.helper.spec.ts
@@ -40,7 +40,7 @@ const allScenarios = {
   ]
 };
 
-describe('WiremockClient', () => {
+describe('WiremockHelper', () => {
 
     it('should add mapping with file reference', () => {
         const filesScope = nock(LOCALHOST_URL)


### PR DESCRIPTION
The last thing I am bordering you is this bug-fix. 
I noticed there is some `User-agent` header enrichment so I added it to all verification requests to be consistent.
I also enabled to not use this feature at all if somebody wants to.

I hope I is the last contribution for now. I have to do something else finally 😄 😄 😄.